### PR TITLE
Rebuild M3: about/CV editors + settings + security + ship

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+dist
+.git
+.github
+.claude
+.env
+.env.*
+!.env.example
+CLAUDE.md
+README.md
+*.log

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,87 @@
+name: build-and-deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-admin
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/personal-blog-admin
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            VITE_API_URL=${{ secrets.VITE_API_URL }}
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Resolve runner IP
+        id: ip
+        run: echo "ip=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
+      - name: Open SSH to runner IP
+        run: |
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${{ secrets.EC2_SG_ID }}" \
+            --protocol tcp --port 22 \
+            --cidr "${{ steps.ip.outputs.ip }}/32"
+      - name: Deploy
+        run: |
+          install -m 700 -d ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            "${{ secrets.EC2_SSH_USER }}@${{ secrets.EC2_HOST }}" \
+            'cd /opt/blog && docker compose pull admin && docker compose up -d admin && docker image prune -f'
+      - name: Revoke SSH access
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id "${{ secrets.EC2_SG_ID }}" \
+            --protocol tcp --port 22 \
+            --cidr "${{ steps.ip.outputs.ip }}/32"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# --- build -------------------------------------------------------------------
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+# The API base URL is inlined at build time.
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+RUN npm run build
+
+# --- runtime (static nginx) --------------------------------------------------
+FROM nginx:1.27-alpine AS runtime
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
+  CMD wget -qO- http://localhost/ >/dev/null 2>&1 || exit 1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# personal-blog-admin
+
+Admin panel for [mikhailbahdashych.me](https://mikhailbahdashych.me) — React + Vite SPA.
+
+Part of a three-repo system: `personal-blog-api` (content API), `personal-blog-front` (public blog), **personal-blog-admin** (this).
+
+## Architecture
+
+- **Vite + React 19 + TypeScript**, React Router, TanStack Query. One hand-rolled stylesheet reusing the blog's token palette — KISS, no UI framework.
+- **Auth**: access token in memory only (never localStorage); the refresh token is the API's HttpOnly cookie. The client refreshes once on a 401 and retries. Real authorization is enforced by the API on every admin endpoint; the client-side gate is UX only.
+- **Content editing**: markdown everywhere. The post editor pairs CodeMirror 6 with a live preview rendered by a **vendored copy of the front's markdown pipeline** (`src/lib/markdown.ts` — keep in sync).
+
+## Screens
+
+Login (credentials → TOTP setup/challenge) · Dashboard · Posts (list + editor) · Assets (upload/manage) · About / CV (profile + work/education/certifications CRUD) · Site settings (hero, intro, social links, SEO, footer) · Security (change password).
+
+## Development
+
+Requires the API running locally (`personal-blog-api`: `npm run dev:infra && npm run migrate && npm run seed && npm run start:dev`).
+
+```bash
+cp .env.example .env.local
+npm install
+npm run dev            # http://localhost:4200
+```
+
+| Script | Purpose |
+| --- | --- |
+| `npm run build` | Production build (static, served by nginx) |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm run lint` | ESLint |
+| `npm run format` | Prettier |
+
+## Environment
+
+`VITE_API_URL` — base URL of the blog API (inlined at build time).
+
+## Deployment
+
+Static build served by nginx (SPA fallback). Docker image built by `.github/workflows/deploy.yml` → GHCR → SSH deploy into the EC2 compose stack. Infra lives in the API repo's [`deploy/`](https://github.com/mikhailbahdashych/personal-blog-api/tree/master/deploy).

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,17 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback: every route resolves to index.html so client routing works.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Hashed assets are immutable.
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/src/api/site.ts
+++ b/src/api/site.ts
@@ -1,0 +1,107 @@
+import { apiRequest } from './client';
+
+export interface SocialLink {
+  label: string;
+  url: string;
+}
+
+export interface SiteConfig {
+  heroTitle: string;
+  heroIntroMd: string;
+  socialLinks: SocialLink[];
+  seoDefaultTitle: string;
+  seoDefaultDescription: string;
+  footerText: string;
+}
+
+export interface Position {
+  id: string;
+  company: string;
+  companyUrl: string | null;
+  title: string;
+  description: string;
+  location: string;
+  logoAssetId: string | null;
+  startDate: string;
+  endDate: string | null;
+  bullets: string[];
+  skills: string[];
+  sortOrder: number;
+}
+
+export interface Education {
+  id: string;
+  institution: string;
+  degree: string;
+  field: string;
+  location: string;
+  logoAssetId: string | null;
+  startDate: string;
+  endDate: string | null;
+  notes: string;
+  sortOrder: number;
+}
+
+export interface Certification {
+  id: string;
+  name: string;
+  issuer: string;
+  description: string;
+  logoAssetId: string | null;
+  issuedDate: string;
+  expiresDate: string | null;
+  credentialUrl: string | null;
+  sortOrder: number;
+}
+
+export interface AboutData {
+  about: {
+    fullName: string;
+    avatarAssetId: string | null;
+    profileMd: string;
+    location: string;
+    contactEmail: string;
+    seoTitle: string | null;
+    seoDescription: string | null;
+  };
+  positions: Position[];
+  education: Education[];
+  certifications: Certification[];
+}
+
+export interface AboutInput {
+  fullName: string;
+  profileMd: string;
+  location: string;
+  contactEmail: string;
+  avatarAssetId?: string;
+  seoTitle?: string;
+  seoDescription?: string;
+}
+
+// --- config ---
+export const getSiteConfig = () => apiRequest<SiteConfig>('/config');
+export const updateSiteConfig = (input: SiteConfig) =>
+  apiRequest<SiteConfig>('/admin/config', { method: 'PUT', body: input });
+
+// --- about ---
+export const getAbout = () => apiRequest<AboutData>('/admin/about');
+export const updateAbout = (input: AboutInput) =>
+  apiRequest<AboutData['about']>('/admin/about', { method: 'PUT', body: input });
+
+// --- CV collections (generic over the three entity kinds) ---
+export type CvKind = 'positions' | 'education' | 'certifications';
+
+export const createCvEntry = <T>(kind: CvKind, input: unknown) =>
+  apiRequest<T>(`/admin/${kind}`, { method: 'POST', body: input });
+export const updateCvEntry = <T>(kind: CvKind, id: string, input: unknown) =>
+  apiRequest<T>(`/admin/${kind}/${id}`, { method: 'PUT', body: input });
+export const deleteCvEntry = (kind: CvKind, id: string) =>
+  apiRequest<void>(`/admin/${kind}/${id}`, { method: 'DELETE' });
+
+// --- account ---
+export const changePassword = (currentPassword: string, newPassword: string) =>
+  apiRequest<void>('/admin/password', {
+    method: 'PUT',
+    body: { currentPassword, newPassword },
+  });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,12 +1,14 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import { RequireAuth } from '@/auth/require-auth';
 import { Layout } from '@/components/layout';
+import { AboutEditorPage } from '@/pages/about-editor';
 import { AssetsPage } from '@/pages/assets';
 import { DashboardPage } from '@/pages/dashboard';
 import { LoginPage } from '@/pages/login';
-import { Placeholder } from '@/pages/placeholder';
 import { PostEditorPage } from '@/pages/post-editor';
 import { PostsListPage } from '@/pages/posts-list';
+import { SecurityPage } from '@/pages/security';
+import { SiteSettingsPage } from '@/pages/site-settings';
 
 export function App() {
   return (
@@ -19,9 +21,9 @@ export function App() {
           <Route path="posts/new" element={<PostEditorPage />} />
           <Route path="posts/:id" element={<PostEditorPage />} />
           <Route path="assets" element={<AssetsPage />} />
-          <Route path="about" element={<Placeholder title="About / CV" />} />
-          <Route path="settings" element={<Placeholder title="Site settings" />} />
-          <Route path="security" element={<Placeholder title="Security" />} />
+          <Route path="about" element={<AboutEditorPage />} />
+          <Route path="settings" element={<SiteSettingsPage />} />
+          <Route path="security" element={<SecurityPage />} />
         </Route>
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />

--- a/src/components/lines-input.tsx
+++ b/src/components/lines-input.tsx
@@ -1,0 +1,28 @@
+/** Edits a string[] as one-item-per-line textarea (bullets, etc.). */
+export function LinesInput({
+  value,
+  onChange,
+  rows = 4,
+  placeholder,
+}: {
+  value: string[];
+  onChange: (lines: string[]) => void;
+  rows?: number;
+  placeholder?: string;
+}) {
+  return (
+    <textarea
+      rows={rows}
+      placeholder={placeholder}
+      value={value.join('\n')}
+      onChange={(e) =>
+        onChange(
+          e.target.value
+            .split('\n')
+            .map((l) => l.trim())
+            .filter(Boolean),
+        )
+      }
+    />
+  );
+}

--- a/src/pages/about-editor.tsx
+++ b/src/pages/about-editor.tsx
@@ -1,0 +1,527 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import {
+  createCvEntry,
+  deleteCvEntry,
+  getAbout,
+  updateAbout,
+  updateCvEntry,
+  type AboutData,
+  type AboutInput,
+  type Certification,
+  type CvKind,
+  type Education,
+  type Position,
+} from '@/api/site';
+import { AssetPicker } from '@/components/asset-picker';
+import { LinesInput } from '@/components/lines-input';
+import { TagInput } from '@/components/tag-input';
+import { useToast } from '@/components/toast';
+
+const PROFILE_EMPTY: AboutInput = {
+  fullName: '',
+  profileMd: '',
+  location: '',
+  contactEmail: '',
+};
+
+export function AboutEditorPage() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const { data, isLoading } = useQuery({ queryKey: ['about'], queryFn: getAbout });
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ['about'] });
+
+  if (isLoading || !data) {
+    return (
+      <div className="page">
+        <h1 className="page-h1">About / CV</h1>
+        <p className="muted">Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page">
+      <h1 className="page-h1">About / CV</h1>
+      <ProfileSection data={data} onSaved={invalidate} toast={toast} />
+      <PositionsSection positions={data.positions} onChanged={invalidate} toast={toast} />
+      <EducationSection education={data.education} onChanged={invalidate} toast={toast} />
+      <CertificationsSection
+        certifications={data.certifications}
+        onChanged={invalidate}
+        toast={toast}
+      />
+    </div>
+  );
+}
+
+type Toast = ReturnType<typeof useToast>;
+
+function ProfileSection({
+  data,
+  onSaved,
+  toast,
+}: {
+  data: AboutData;
+  onSaved: () => void;
+  toast: Toast;
+}) {
+  const [form, setForm] = useState<AboutInput>(PROFILE_EMPTY);
+  const [avatarId, setAvatarId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setForm({
+      fullName: data.about.fullName,
+      profileMd: data.about.profileMd,
+      location: data.about.location,
+      contactEmail: data.about.contactEmail,
+      seoTitle: data.about.seoTitle ?? undefined,
+      seoDescription: data.about.seoDescription ?? undefined,
+    });
+    setAvatarId(data.about.avatarAssetId);
+  }, [data]);
+
+  const set = <K extends keyof AboutInput>(key: K, value: AboutInput[K]) =>
+    setForm((c) => ({ ...c, [key]: value }));
+
+  const save = useMutation({
+    mutationFn: () => updateAbout({ ...form, avatarAssetId: avatarId ?? undefined }),
+    onSuccess: () => {
+      onSaved();
+      toast('Profile saved');
+    },
+    onError: () => toast('Save failed.', 'error'),
+  });
+
+  return (
+    <section className="cv-section">
+      <div className="cv-section-head">
+        <h2>Profile</h2>
+        <button className="btn primary" disabled={save.isPending} onClick={() => save.mutate()}>
+          Save profile
+        </button>
+      </div>
+      <div className="cv-grid-2">
+        <label className="stacked">
+          <span>Full name</span>
+          <input value={form.fullName} onChange={(e) => set('fullName', e.target.value)} />
+        </label>
+        <label className="stacked">
+          <span>Location</span>
+          <input value={form.location} onChange={(e) => set('location', e.target.value)} />
+        </label>
+      </div>
+      <label className="stacked">
+        <span>Contact email</span>
+        <input value={form.contactEmail} onChange={(e) => set('contactEmail', e.target.value)} />
+      </label>
+      <label className="stacked">
+        <span>Profile (markdown)</span>
+        <textarea
+          rows={4}
+          value={form.profileMd}
+          onChange={(e) => set('profileMd', e.target.value)}
+        />
+      </label>
+      <label className="stacked">
+        <span>Avatar</span>
+        <AssetPicker value={avatarId} onChange={setAvatarId} />
+      </label>
+    </section>
+  );
+}
+
+/** Generic add/edit/delete list for a CV entity kind. */
+function CvList<T extends { id: string; sortOrder: number }>({
+  title,
+  kind,
+  items,
+  onChanged,
+  toast,
+  makeEmpty,
+  renderFields,
+  summarize,
+}: {
+  title: string;
+  kind: CvKind;
+  items: T[];
+  onChanged: () => void;
+  toast: Toast;
+  makeEmpty: (sortOrder: number) => Omit<T, 'id'>;
+  renderFields: (draft: Omit<T, 'id'>, update: (patch: Partial<T>) => void) => React.ReactNode;
+  summarize: (item: T) => string;
+}) {
+  const [editing, setEditing] = useState<{ id: string | null; draft: Omit<T, 'id'> } | null>(null);
+
+  const save = useMutation({
+    mutationFn: ({ id, draft }: { id: string | null; draft: Omit<T, 'id'> }) =>
+      id ? updateCvEntry<T>(kind, id, draft) : createCvEntry<T>(kind, draft),
+    onSuccess: () => {
+      onChanged();
+      setEditing(null);
+      toast('Saved');
+    },
+    onError: () => toast('Save failed.', 'error'),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => deleteCvEntry(kind, id),
+    onSuccess: () => {
+      onChanged();
+      toast('Deleted');
+    },
+    onError: () => toast('Delete failed.', 'error'),
+  });
+
+  const startNew = () => setEditing({ id: null, draft: makeEmpty(items.length) });
+
+  return (
+    <section className="cv-section">
+      <div className="cv-section-head">
+        <h2>{title}</h2>
+        <button className="btn small" onClick={startNew}>
+          Add
+        </button>
+      </div>
+
+      <div className="cv-list">
+        {items.map((item) => (
+          <div key={item.id} className="cv-item">
+            <span className="cv-item-summary">{summarize(item)}</span>
+            <div className="cv-item-actions">
+              <button
+                className="btn ghost small"
+                onClick={() => {
+                  const draft = { ...item } as Partial<T>;
+                  delete draft.id;
+                  setEditing({ id: item.id, draft: draft as Omit<T, 'id'> });
+                }}
+              >
+                Edit
+              </button>
+              <button
+                className="btn ghost small danger"
+                onClick={() => {
+                  if (confirm('Delete this entry?')) {
+                    remove.mutate(item.id);
+                  }
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        ))}
+        {items.length === 0 && <p className="muted small">None yet.</p>}
+      </div>
+
+      {editing && (
+        <div className="cv-editor">
+          {renderFields(editing.draft, (patch) =>
+            setEditing((cur) => (cur ? { ...cur, draft: { ...cur.draft, ...patch } } : cur)),
+          )}
+          <div className="cv-editor-actions">
+            <button className="btn" onClick={() => setEditing(null)}>
+              Cancel
+            </button>
+            <button
+              className="btn primary"
+              disabled={save.isPending}
+              onClick={() => save.mutate(editing)}
+            >
+              Save entry
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PositionsSection({
+  positions,
+  onChanged,
+  toast,
+}: {
+  positions: Position[];
+  onChanged: () => void;
+  toast: Toast;
+}) {
+  return (
+    <CvList<Position>
+      title="Work history"
+      kind="positions"
+      items={positions}
+      onChanged={onChanged}
+      toast={toast}
+      summarize={(p) => `${p.title} · ${p.company}`}
+      makeEmpty={(sortOrder) => ({
+        company: '',
+        companyUrl: null,
+        title: '',
+        description: '',
+        location: '',
+        logoAssetId: null,
+        startDate: '',
+        endDate: null,
+        bullets: [],
+        skills: [],
+        sortOrder,
+      })}
+      renderFields={(draft, update) => (
+        <>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Role title</span>
+              <input value={draft.title} onChange={(e) => update({ title: e.target.value })} />
+            </label>
+            <label className="stacked">
+              <span>Company</span>
+              <input value={draft.company} onChange={(e) => update({ company: e.target.value })} />
+            </label>
+          </div>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Company URL</span>
+              <input
+                value={draft.companyUrl ?? ''}
+                onChange={(e) => update({ companyUrl: e.target.value || null })}
+              />
+            </label>
+            <label className="stacked">
+              <span>Location</span>
+              <input
+                value={draft.location}
+                onChange={(e) => update({ location: e.target.value })}
+              />
+            </label>
+          </div>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Start date (YYYY-MM-DD)</span>
+              <input
+                value={draft.startDate}
+                onChange={(e) => update({ startDate: e.target.value })}
+              />
+            </label>
+            <label className="stacked">
+              <span>End date (blank = present)</span>
+              <input
+                value={draft.endDate ?? ''}
+                onChange={(e) => update({ endDate: e.target.value || null })}
+              />
+            </label>
+          </div>
+          <label className="stacked">
+            <span>Blurb</span>
+            <input
+              value={draft.description}
+              onChange={(e) => update({ description: e.target.value })}
+            />
+          </label>
+          <label className="stacked">
+            <span>Bullets (one per line)</span>
+            <LinesInput value={draft.bullets} onChange={(bullets) => update({ bullets })} />
+          </label>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Skills</span>
+              <TagInput value={draft.skills} onChange={(skills) => update({ skills })} />
+            </label>
+            <label className="stacked">
+              <span>Sort order</span>
+              <input
+                type="number"
+                value={draft.sortOrder}
+                onChange={(e) => update({ sortOrder: Number(e.target.value) })}
+              />
+            </label>
+          </div>
+          <label className="stacked">
+            <span>Logo</span>
+            <AssetPicker
+              value={draft.logoAssetId}
+              onChange={(logoAssetId) => update({ logoAssetId })}
+            />
+          </label>
+        </>
+      )}
+    />
+  );
+}
+
+function EducationSection({
+  education,
+  onChanged,
+  toast,
+}: {
+  education: Education[];
+  onChanged: () => void;
+  toast: Toast;
+}) {
+  return (
+    <CvList<Education>
+      title="Education"
+      kind="education"
+      items={education}
+      onChanged={onChanged}
+      toast={toast}
+      summarize={(e) => `${e.degree} ${e.field} · ${e.institution}`}
+      makeEmpty={(sortOrder) => ({
+        institution: '',
+        degree: '',
+        field: '',
+        location: '',
+        logoAssetId: null,
+        startDate: '',
+        endDate: null,
+        notes: '',
+        sortOrder,
+      })}
+      renderFields={(draft, update) => (
+        <>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Degree</span>
+              <input value={draft.degree} onChange={(e) => update({ degree: e.target.value })} />
+            </label>
+            <label className="stacked">
+              <span>Field</span>
+              <input value={draft.field} onChange={(e) => update({ field: e.target.value })} />
+            </label>
+          </div>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Institution</span>
+              <input
+                value={draft.institution}
+                onChange={(e) => update({ institution: e.target.value })}
+              />
+            </label>
+            <label className="stacked">
+              <span>Location</span>
+              <input
+                value={draft.location}
+                onChange={(e) => update({ location: e.target.value })}
+              />
+            </label>
+          </div>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Start date</span>
+              <input
+                value={draft.startDate}
+                onChange={(e) => update({ startDate: e.target.value })}
+              />
+            </label>
+            <label className="stacked">
+              <span>End date</span>
+              <input
+                value={draft.endDate ?? ''}
+                onChange={(e) => update({ endDate: e.target.value || null })}
+              />
+            </label>
+          </div>
+          <label className="stacked">
+            <span>Notes / thesis</span>
+            <input value={draft.notes} onChange={(e) => update({ notes: e.target.value })} />
+          </label>
+          <label className="stacked">
+            <span>Sort order</span>
+            <input
+              type="number"
+              value={draft.sortOrder}
+              onChange={(e) => update({ sortOrder: Number(e.target.value) })}
+            />
+          </label>
+        </>
+      )}
+    />
+  );
+}
+
+function CertificationsSection({
+  certifications,
+  onChanged,
+  toast,
+}: {
+  certifications: Certification[];
+  onChanged: () => void;
+  toast: Toast;
+}) {
+  return (
+    <CvList<Certification>
+      title="Certifications"
+      kind="certifications"
+      items={certifications}
+      onChanged={onChanged}
+      toast={toast}
+      summarize={(c) => `${c.name} · ${c.issuer}`}
+      makeEmpty={(sortOrder) => ({
+        name: '',
+        issuer: '',
+        description: '',
+        logoAssetId: null,
+        issuedDate: '',
+        expiresDate: null,
+        credentialUrl: null,
+        sortOrder,
+      })}
+      renderFields={(draft, update) => (
+        <>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Name</span>
+              <input value={draft.name} onChange={(e) => update({ name: e.target.value })} />
+            </label>
+            <label className="stacked">
+              <span>Issuer</span>
+              <input value={draft.issuer} onChange={(e) => update({ issuer: e.target.value })} />
+            </label>
+          </div>
+          <label className="stacked">
+            <span>Description</span>
+            <input
+              value={draft.description}
+              onChange={(e) => update({ description: e.target.value })}
+            />
+          </label>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Issued (YYYY-MM-DD)</span>
+              <input
+                value={draft.issuedDate}
+                onChange={(e) => update({ issuedDate: e.target.value })}
+              />
+            </label>
+            <label className="stacked">
+              <span>Expires (blank = none)</span>
+              <input
+                value={draft.expiresDate ?? ''}
+                onChange={(e) => update({ expiresDate: e.target.value || null })}
+              />
+            </label>
+          </div>
+          <div className="cv-grid-2">
+            <label className="stacked">
+              <span>Credential URL</span>
+              <input
+                value={draft.credentialUrl ?? ''}
+                onChange={(e) => update({ credentialUrl: e.target.value || null })}
+              />
+            </label>
+            <label className="stacked">
+              <span>Sort order</span>
+              <input
+                type="number"
+                value={draft.sortOrder}
+                onChange={(e) => update({ sortOrder: Number(e.target.value) })}
+              />
+            </label>
+          </div>
+        </>
+      )}
+    />
+  );
+}

--- a/src/pages/placeholder.tsx
+++ b/src/pages/placeholder.tsx
@@ -1,9 +1,0 @@
-/** Temporary stand-in for screens delivered in M2/M3. */
-export function Placeholder({ title }: { title: string }) {
-  return (
-    <div className="page">
-      <h1 className="page-h1">{title}</h1>
-      <p className="muted">Coming in the next milestone.</p>
-    </div>
-  );
-}

--- a/src/pages/security.tsx
+++ b/src/pages/security.tsx
@@ -1,0 +1,84 @@
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import { ApiError } from '@/api/client';
+import { changePassword } from '@/api/site';
+import { useToast } from '@/components/toast';
+
+export function SecurityPage() {
+  const toast = useToast();
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirm, setConfirm] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: () => changePassword(current, next),
+    onSuccess: () => {
+      toast('Password changed');
+      setCurrent('');
+      setNext('');
+      setConfirm('');
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 401) {
+        toast('Current password is incorrect.', 'error');
+      } else {
+        toast('Could not change password.', 'error');
+      }
+    },
+  });
+
+  const mismatch = next !== '' && confirm !== '' && next !== confirm;
+  const canSubmit = current !== '' && next.length >= 12 && next === confirm;
+
+  return (
+    <div className="page narrow">
+      <h1 className="page-h1">Security</h1>
+
+      <form
+        className="stacked-form"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (canSubmit) {
+            mutation.mutate();
+          }
+        }}
+      >
+        <label className="stacked">
+          <span>Current password</span>
+          <input
+            type="password"
+            autoComplete="current-password"
+            value={current}
+            onChange={(e) => setCurrent(e.target.value)}
+          />
+        </label>
+
+        <label className="stacked">
+          <span>New password (min 12 characters)</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={next}
+            onChange={(e) => setNext(e.target.value)}
+          />
+        </label>
+
+        <label className="stacked">
+          <span>Confirm new password</span>
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+        </label>
+
+        {mismatch && <p className="form-error">Passwords don&apos;t match.</p>}
+
+        <button type="submit" className="btn primary" disabled={!canSubmit || mutation.isPending}>
+          Change password
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/site-settings.tsx
+++ b/src/pages/site-settings.tsx
@@ -1,0 +1,133 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import { getSiteConfig, updateSiteConfig, type SiteConfig } from '@/api/site';
+import { useToast } from '@/components/toast';
+
+const EMPTY: SiteConfig = {
+  heroTitle: '',
+  heroIntroMd: '',
+  socialLinks: [],
+  seoDefaultTitle: '',
+  seoDefaultDescription: '',
+  footerText: '',
+};
+
+export function SiteSettingsPage() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+  const [form, setForm] = useState<SiteConfig>(EMPTY);
+
+  const { data } = useQuery({ queryKey: ['config'], queryFn: getSiteConfig });
+
+  useEffect(() => {
+    if (data) {
+      setForm(data);
+    }
+  }, [data]);
+
+  const set = <K extends keyof SiteConfig>(key: K, value: SiteConfig[K]) =>
+    setForm((current) => ({ ...current, [key]: value }));
+
+  const save = useMutation({
+    mutationFn: () => updateSiteConfig(form),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['config'] });
+      toast('Saved');
+    },
+    onError: () => toast('Save failed.', 'error'),
+  });
+
+  const setLink = (index: number, key: 'label' | 'url', value: string) =>
+    set(
+      'socialLinks',
+      form.socialLinks.map((link, i) => (i === index ? { ...link, [key]: value } : link)),
+    );
+
+  return (
+    <div className="page">
+      <div className="page-head-row">
+        <h1 className="page-h1">Site settings</h1>
+        <button className="btn primary" disabled={save.isPending} onClick={() => save.mutate()}>
+          Save
+        </button>
+      </div>
+
+      <label className="stacked">
+        <span>Hero title</span>
+        <textarea
+          rows={2}
+          value={form.heroTitle}
+          onChange={(e) => set('heroTitle', e.target.value)}
+        />
+      </label>
+
+      <label className="stacked">
+        <span>Hero intro (markdown)</span>
+        <textarea
+          rows={3}
+          value={form.heroIntroMd}
+          onChange={(e) => set('heroIntroMd', e.target.value)}
+        />
+      </label>
+
+      <div className="stacked">
+        <span className="field-label">Social links</span>
+        <div className="social-links">
+          {form.socialLinks.map((link, index) => (
+            <div key={index} className="social-row">
+              <input
+                placeholder="label"
+                value={link.label}
+                onChange={(e) => setLink(index, 'label', e.target.value)}
+              />
+              <input
+                placeholder="https://…"
+                value={link.url}
+                onChange={(e) => setLink(index, 'url', e.target.value)}
+              />
+              <button
+                className="btn ghost small danger"
+                onClick={() =>
+                  set(
+                    'socialLinks',
+                    form.socialLinks.filter((_, i) => i !== index),
+                  )
+                }
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+          <button
+            className="btn small"
+            onClick={() => set('socialLinks', [...form.socialLinks, { label: '', url: '' }])}
+          >
+            Add link
+          </button>
+        </div>
+      </div>
+
+      <label className="stacked">
+        <span>Default SEO title</span>
+        <input
+          value={form.seoDefaultTitle}
+          onChange={(e) => set('seoDefaultTitle', e.target.value)}
+        />
+      </label>
+
+      <label className="stacked">
+        <span>Default SEO description</span>
+        <textarea
+          rows={2}
+          value={form.seoDefaultDescription}
+          onChange={(e) => set('seoDefaultDescription', e.target.value)}
+        />
+      </label>
+
+      <label className="stacked">
+        <span>Footer text</span>
+        <input value={form.footerText} onChange={(e) => set('footerText', e.target.value)} />
+      </label>
+    </div>
+  );
+}

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -686,3 +686,102 @@ select:focus {
   border-color: var(--danger);
   color: var(--danger);
 }
+
+/* --- M3: settings, security, about/CV ---------------------------------------- */
+
+.narrow {
+  max-width: 460px;
+}
+
+.field-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.stacked-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.social-links {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.social-row {
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.cv-section {
+  border-top: 1px solid var(--border);
+  padding-top: 24px;
+  margin-top: 28px;
+}
+
+.cv-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.cv-section-head h2 {
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.cv-grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.cv-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.cv-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+}
+
+.cv-item-summary {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.cv-item-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.cv-editor {
+  margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--wash);
+  padding: 18px;
+}
+
+.cv-editor-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}


### PR DESCRIPTION
Final admin milestone, stacked on #44. The admin repo is now feature-complete — the whole rebuild is done.

## Screens
- **About / CV**: profile block (name, location, email, markdown bio, avatar picker) + a generic add/edit/delete list reused for **work history**, **education**, and **certifications** — each with its own inline editor (dates, company/URL, bullets one-per-line, skill chips, sort order, logo/credential fields).
- **Site settings**: hero title + intro, a **social-links editor** (add/remove label+URL rows), default SEO title/description, footer text.
- **Security**: change password (min 12 chars, confirmation match, wrong-current-password surfaces a friendly error).

## Ship
- **Static Dockerfile**: Vite build served by **nginx** with SPA fallback + immutable hashed-asset caching; `VITE_API_URL` inlined at build time.
- **CI**: typecheck + lint → GHCR → SSH deploy, same hardening as the other two repos (runner-IP-only SG rule, pinned host key, `if: always()` revoke).

## Verified
About/CV editor **exercised live in Chrome against the API** — all four sections render from seed data, the inline position editor opens fully populated. Settings + security render. Typecheck + lint + `vite build` + **Docker image build** all clean.

## Merge order
#43 → #44 → this. After all three repos' PR chains merge, follow `personal-blog-api/deploy/DEPLOYMENT.md` to bring the stack up on EC2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)