### PR TITLE
Security: block executable URLs in the markdown preview

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,10 @@ jobs:
           echo "${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             "${{ secrets.EC2_SSH_USER }}@${{ secrets.EC2_HOST }}" \
-            'cd /opt/blog && docker compose pull admin && docker compose up -d admin && docker image prune -f'
+            'cd /opt/blog \
+             && docker compose -f docker-compose.prod.yml pull admin \
+             && docker compose -f docker-compose.prod.yml up -d admin \
+             && docker image prune -f'
       - name: Revoke SSH access
         if: always()
         run: |

--- a/src/api/site.ts
+++ b/src/api/site.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from './client';
+import { setAccessToken } from './token-store';
 
 export interface SocialLink {
   label: string;
@@ -100,8 +101,16 @@ export const deleteCvEntry = (kind: CvKind, id: string) =>
   apiRequest<void>(`/admin/${kind}/${id}`, { method: 'DELETE' });
 
 // --- account ---
-export const changePassword = (currentPassword: string, newPassword: string) =>
-  apiRequest<void>('/admin/password', {
+/**
+ * Changing the password revokes the old session server-side, so the response
+ * carries a replacement access token (and rotates the refresh cookie). Storing
+ * it keeps this tab signed in; any other tab or device holding the old tokens
+ * is logged out.
+ */
+export const changePassword = async (currentPassword: string, newPassword: string) => {
+  const { accessToken } = await apiRequest<{ accessToken: string }>('/admin/password', {
     method: 'PUT',
     body: { currentPassword, newPassword },
   });
+  setAccessToken(accessToken);
+};

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -29,6 +29,43 @@ const isElement = (node: ElementContent | RootContent | undefined, tag?: string)
 const isWhitespace = (node: ElementContent | RootContent | undefined): boolean =>
   !!node && node.type === 'text' && node.value.trim() === '';
 
+/**
+ * Strip link/image URLs that carry an executable scheme.
+ *
+ * remark-rehype does not filter URLs, so `[x](javascript:alert(1))` otherwise
+ * survives into the rendered href even though raw HTML is escaped. Anything
+ * without a scheme (relative paths, fragments, query-only) is left alone; a URL
+ * with a scheme has to be on the allowlist to be kept.
+ */
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+const URL_ATTRIBUTES: Record<string, string> = { a: 'href', img: 'src', image: 'href' };
+
+function isSafeUrl(value: string): boolean {
+  // Browsers drop whitespace and control characters while parsing a URL, so
+  // `java\tscript:alert(1)` still executes. Drop everything up to and including
+  // U+0020 before reading the scheme; over-stripping only ever fails closed.
+  const bare = Array.from(value)
+    .filter((char) => char.codePointAt(0)! > 0x20)
+    .join('');
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(bare);
+  return scheme === null || SAFE_URL_SCHEMES.has(scheme[1].toLowerCase() + ':');
+}
+
+function rehypeSafeUrls() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element) => {
+      const attribute = URL_ATTRIBUTES[node.tagName];
+      if (!attribute) {
+        return;
+      }
+      const value = node.properties[attribute];
+      if (typeof value === 'string' && !isSafeUrl(value)) {
+        delete node.properties[attribute];
+      }
+    });
+  };
+}
+
 function rehypeFigures() {
   return (tree: Root) => {
     visit(tree, 'element', (node: Element, index, parent) => {
@@ -139,6 +176,7 @@ const processor = unified()
   .use(rehypeTableCaptions)
   .use(rehypeTableWrap)
   .use(rehypeFigures)
+  .use(rehypeSafeUrls)
   .use(collectToc)
   .use(rehypeStringify);
 


### PR DESCRIPTION
Part of the pre-deployment security review. Companion to `personal-blog-api#49` and `personal-blog-front#85`.

## `javascript:` URLs in the live preview

The vendored markdown pipeline had the same gap as the frontend: raw HTML is dropped, but `[x](javascript:alert(1))` reached the rendered `href` intact.

This matters more here than on the public site. The preview renders via `dangerouslySetInnerHTML` into the origin that holds the in-memory access token — so markdown pasted into the editor could read it and act as the admin. `rehypeSafeUrls` is the same plugin the frontend now uses; the two copies are kept in sync deliberately.

## Password change flow

The API now re-issues the session on password change (invalidating every earlier refresh token) and returns a replacement access token. The client stores it, so this tab stays signed in while any other copy of the old credentials is cut off.

## Verified sound, no change needed

- The access token lives in memory only. After boot, `localStorage` and `sessionStorage` are both **empty** and no cookie is visible to JS — confirmed in a real browser.
- The built bundle ships **zero inline scripts**, so the strict `script-src 'self'` CSP added on the admin vhost in `personal-blog-api#49` applies without weakening it.
- Scanning the full 1.5MB bundle in-browser found no secrets.
- Unauthenticated load redirects to `/login`, and the API independently enforces auth on every admin route.

## Also

The deploy step now names `docker-compose.prod.yml`, matching the API's workflow — plain `docker compose` finds no compose file on the host, so the current step would fail at cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)