### PR TITLE
Full-width editor, asset metadata, loading states, form validation

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -10,6 +10,24 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Pull the human-readable reason out of an API error.
+ *
+ * Validation failures come back as `{ message: ['slug must be …'] }`, which is
+ * far more useful than a generic "Save failed." — surface it verbatim and fall
+ * back to the caller's wording when the shape is anything else.
+ */
+export function errorMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof ApiError)) {
+    return fallback;
+  }
+  const { message } = (error.body ?? {}) as { message?: unknown };
+  if (Array.isArray(message) && message.every((m) => typeof m === 'string') && message.length > 0) {
+    return message.join('. ');
+  }
+  return typeof message === 'string' && message !== '' ? message : fallback;
+}
+
 interface RequestOptions {
   method?: string;
   body?: unknown;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -54,6 +54,8 @@ export interface PostInput {
 export interface Asset {
   id: string;
   s3Key: string;
+  /** Name the file was uploaded under; '' for assets stored before it was kept. */
+  filename: string;
   url: string;
   contentType: string;
   sizeBytes: number;

--- a/src/auth/require-auth.tsx
+++ b/src/auth/require-auth.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet } from 'react-router-dom';
 import { useAuth } from './auth-context';
+import { LoadingBlock } from '@/components/loader';
 
 /**
  * Client-side gate: redirects to /login when there's no session. This is a UX
@@ -9,7 +10,11 @@ export function RequireAuth() {
   const { authenticated, loading } = useAuth();
 
   if (loading) {
-    return <div className="page-loading">Loading…</div>;
+    return (
+      <div className="page-loading">
+        <LoadingBlock label="Restoring session…" />
+      </div>
+    );
   }
   if (!authenticated) {
     return <Navigate to="/login" replace />;

--- a/src/components/loader.tsx
+++ b/src/components/loader.tsx
@@ -1,0 +1,41 @@
+/**
+ * Loading affordances for the admin.
+ *
+ * `Spinner` is the inline mark; `LoadingBlock` is what a page shows while its
+ * first query resolves. Both are labelled for screen readers, since an
+ * unlabelled spinner announces nothing at all.
+ */
+
+export function Spinner({ label }: { label?: string }) {
+  return (
+    <span className="spinner" role="status" aria-label={label ?? 'Loading'}>
+      <svg viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+        <circle
+          cx="12"
+          cy="12"
+          r="9"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          opacity="0.2"
+        />
+        <path
+          d="M21 12a9 9 0 0 0-9-9"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="3"
+          strokeLinecap="round"
+        />
+      </svg>
+    </span>
+  );
+}
+
+export function LoadingBlock({ label = 'Loading…' }: { label?: string }) {
+  return (
+    <div className="loading-block">
+      <Spinner label={label} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/src/pages/about-editor.tsx
+++ b/src/pages/about-editor.tsx
@@ -18,6 +18,7 @@ import { AssetPicker } from '@/components/asset-picker';
 import { LinesInput } from '@/components/lines-input';
 import { TagInput } from '@/components/tag-input';
 import { useToast } from '@/components/toast';
+import { LoadingBlock } from '@/components/loader';
 
 const PROFILE_EMPTY: AboutInput = {
   fullName: '',
@@ -37,7 +38,7 @@ export function AboutEditorPage() {
     return (
       <div className="page">
         <h1 className="page-h1">About / CV</h1>
-        <p className="muted">Loading…</p>
+        <LoadingBlock label="Loading CV…" />
       </div>
     );
   }

--- a/src/pages/about-editor.tsx
+++ b/src/pages/about-editor.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
+import { errorMessage } from '@/api/client';
 import {
   createCvEntry,
   deleteCvEntry,
@@ -91,7 +92,7 @@ function ProfileSection({
       onSaved();
       toast('Profile saved');
     },
-    onError: () => toast('Save failed.', 'error'),
+    onError: (err) => toast(errorMessage(err, 'Save failed.'), 'error'),
   });
 
   return (
@@ -132,6 +133,18 @@ function ProfileSection({
   );
 }
 
+/**
+ * A date the API will accept for @IsDateString: an ISO calendar date that also
+ * refers to a real day (2025-02-30 parses as a string but is not a date).
+ */
+function isCalendarDate(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+  const date = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(date.getTime()) && date.toISOString().startsWith(value);
+}
+
 /** Generic add/edit/delete list for a CV entity kind. */
 function CvList<T extends { id: string; sortOrder: number }>({
   title,
@@ -142,6 +155,7 @@ function CvList<T extends { id: string; sortOrder: number }>({
   makeEmpty,
   renderFields,
   summarize,
+  missingRequired,
 }: {
   title: string;
   kind: CvKind;
@@ -151,6 +165,8 @@ function CvList<T extends { id: string; sortOrder: number }>({
   makeEmpty: (sortOrder: number) => Omit<T, 'id'>;
   renderFields: (draft: Omit<T, 'id'>, update: (patch: Partial<T>) => void) => React.ReactNode;
   summarize: (item: T) => string;
+  /** Labels of fields the API requires that this draft has not filled in yet. */
+  missingRequired: (draft: Omit<T, 'id'>) => string[];
 }) {
   const [editing, setEditing] = useState<{ id: string | null; draft: Omit<T, 'id'> } | null>(null);
 
@@ -162,7 +178,7 @@ function CvList<T extends { id: string; sortOrder: number }>({
       setEditing(null);
       toast('Saved');
     },
-    onError: () => toast('Save failed.', 'error'),
+    onError: (err) => toast(errorMessage(err, 'Save failed.'), 'error'),
   });
 
   const remove = useMutation({
@@ -175,6 +191,8 @@ function CvList<T extends { id: string; sortOrder: number }>({
   });
 
   const startNew = () => setEditing({ id: null, draft: makeEmpty(items.length) });
+
+  const missing = editing ? missingRequired(editing.draft) : [];
 
   return (
     <section className="cv-section">
@@ -222,12 +240,15 @@ function CvList<T extends { id: string; sortOrder: number }>({
             setEditing((cur) => (cur ? { ...cur, draft: { ...cur.draft, ...patch } } : cur)),
           )}
           <div className="cv-editor-actions">
+            {missing.length > 0 && (
+              <span className="field-error">Required: {missing.join(', ')}</span>
+            )}
             <button className="btn" onClick={() => setEditing(null)}>
               Cancel
             </button>
             <button
               className="btn primary"
-              disabled={save.isPending}
+              disabled={save.isPending || missing.length > 0}
               onClick={() => save.mutate(editing)}
             >
               Save entry
@@ -256,6 +277,11 @@ function PositionsSection({
       onChanged={onChanged}
       toast={toast}
       summarize={(p) => `${p.title} · ${p.company}`}
+      missingRequired={(p) => [
+        ...(p.title.trim() === '' ? ['role title'] : []),
+        ...(p.company.trim() === '' ? ['company'] : []),
+        ...(isCalendarDate(p.startDate) ? [] : ['start date (YYYY-MM-DD)']),
+      ]}
       makeEmpty={(sortOrder) => ({
         company: '',
         companyUrl: null,
@@ -368,6 +394,11 @@ function EducationSection({
       onChanged={onChanged}
       toast={toast}
       summarize={(e) => `${e.degree} ${e.field} · ${e.institution}`}
+      missingRequired={(e) => [
+        ...(e.institution.trim() === '' ? ['institution'] : []),
+        ...(e.degree.trim() === '' ? ['degree'] : []),
+        ...(isCalendarDate(e.startDate) ? [] : ['start date (YYYY-MM-DD)']),
+      ]}
       makeEmpty={(sortOrder) => ({
         institution: '',
         degree: '',
@@ -458,6 +489,11 @@ function CertificationsSection({
       onChanged={onChanged}
       toast={toast}
       summarize={(c) => `${c.name} · ${c.issuer}`}
+      missingRequired={(c) => [
+        ...(c.name.trim() === '' ? ['name'] : []),
+        ...(c.issuer.trim() === '' ? ['issuer'] : []),
+        ...(isCalendarDate(c.issuedDate) ? [] : ['issued date (YYYY-MM-DD)']),
+      ]}
       makeEmpty={(sortOrder) => ({
         name: '',
         issuer: '',

--- a/src/pages/assets.tsx
+++ b/src/pages/assets.tsx
@@ -1,11 +1,31 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { deleteAsset, listAssets, uploadAsset } from '@/api/assets';
 import type { Asset } from '@/api/types';
+import { LoadingBlock, Spinner } from '@/components/loader';
 import { useToast } from '@/components/toast';
+
+const PER_PAGE_OPTIONS = [24, 48, 96] as const;
 
 function markdownSnippet(asset: Asset): string {
   return `![${asset.alt ?? ''}](${asset.url}${asset.alt ? ` "${asset.alt}"` : ''})`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  const kb = bytes / 1024;
+  return kb < 1024 ? `${Math.round(kb)} KB` : `${(kb / 1024).toFixed(1)} MB`;
+}
+
+/** 'image/svg+xml' -> 'SVG'. Just the useful half, uppercased. */
+function formatType(contentType: string): string {
+  return (contentType.split('/')[1] ?? contentType).split('+')[0].toUpperCase();
+}
+
+function formatDate(iso: string): string {
+  return iso.slice(0, 10);
 }
 
 export function AssetsPage() {
@@ -15,11 +35,21 @@ export function AssetsPage() {
   const [search, setSearch] = useState('');
   const [alt, setAlt] = useState('');
   const [dragging, setDragging] = useState(false);
+  const [page, setPage] = useState(1);
+  const [per, setPer] = useState<number>(PER_PAGE_OPTIONS[0]);
 
-  const { data } = useQuery({
-    queryKey: ['assets', search],
-    queryFn: () => listAssets({ search: search || undefined, page: 1, per: 60 }),
+  // A narrowed search almost always has fewer pages than the current offset.
+  useEffect(() => {
+    setPage(1);
+  }, [search, per]);
+
+  const { data, isLoading, isFetching } = useQuery({
+    queryKey: ['assets', search, page, per],
+    queryFn: () => listAssets({ search: search || undefined, page, per }),
+    placeholderData: (previous) => previous,
   });
+
+  const totalPages = data ? Math.max(1, Math.ceil(data.total / data.per)) : 1;
 
   const upload = useMutation({
     mutationFn: (file: File) => uploadAsset(file, alt),
@@ -80,7 +110,13 @@ export function AssetsPage() {
           onFiles(e.dataTransfer.files);
         }}
       >
-        {upload.isPending ? 'Uploading…' : 'Drop an image here or click to choose (max 10MB)'}
+        {upload.isPending ? (
+          <>
+            <Spinner label="Uploading" /> Uploading…
+          </>
+        ) : (
+          'Drop an image here or click to choose (max 10MB)'
+        )}
         <input
           ref={fileInput}
           type="file"
@@ -90,36 +126,96 @@ export function AssetsPage() {
         />
       </div>
 
-      <input
-        className="asset-search"
-        placeholder="Search assets…"
-        value={search}
-        onChange={(e) => setSearch(e.target.value)}
-      />
+      <div className="asset-toolbar">
+        <input
+          className="asset-search"
+          placeholder="Search by name or alt text…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <label className="inline-select">
+          <span>per page</span>
+          <select value={per} onChange={(e) => setPer(Number(e.target.value))}>
+            {PER_PAGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+        {data && (
+          <span className="muted small asset-count">
+            {data.total} {data.total === 1 ? 'image' : 'images'}
+            {isFetching && !isLoading && <Spinner label="Refreshing" />}
+          </span>
+        )}
+      </div>
 
-      <div className="asset-grid">
-        {data?.items.map((asset) => (
-          <div key={asset.id} className="asset-card">
-            <img src={asset.url} alt={asset.alt ?? ''} />
-            <div className="asset-card-actions">
-              <button className="btn ghost small" onClick={() => copySnippet(asset)}>
-                Copy MD
-              </button>
+      {isLoading ? (
+        <LoadingBlock label="Loading assets…" />
+      ) : (
+        <>
+          <div className="asset-grid">
+            {data?.items.map((asset) => (
+              <figure key={asset.id} className="asset-card">
+                <img src={asset.url} alt={asset.alt ?? ''} loading="lazy" />
+                <figcaption className="asset-meta">
+                  <span className="asset-name" title={asset.filename || asset.s3Key}>
+                    {asset.filename || '(no filename)'}
+                  </span>
+                  <span className="asset-facts">
+                    {formatType(asset.contentType)} · {formatBytes(asset.sizeBytes)} ·{' '}
+                    {formatDate(asset.createdAt)}
+                  </span>
+                  <span className="asset-alt" title={asset.alt ?? ''}>
+                    {asset.alt ? `alt: ${asset.alt}` : 'no alt text'}
+                  </span>
+                </figcaption>
+                <div className="asset-card-actions">
+                  <button className="btn ghost small" onClick={() => copySnippet(asset)}>
+                    Copy MD
+                  </button>
+                  <button
+                    className="btn ghost small danger"
+                    onClick={() => {
+                      if (confirm('Delete this asset?')) {
+                        remove.mutate(asset.id);
+                      }
+                    }}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </figure>
+            ))}
+            {data && data.items.length === 0 && (
+              <p className="muted">{search ? 'Nothing matches that search.' : 'No assets yet.'}</p>
+            )}
+          </div>
+
+          {totalPages > 1 && (
+            <div className="table-pager">
               <button
-                className="btn ghost small danger"
-                onClick={() => {
-                  if (confirm('Delete this asset?')) {
-                    remove.mutate(asset.id);
-                  }
-                }}
+                className="btn small"
+                disabled={page <= 1 || isFetching}
+                onClick={() => setPage((p) => p - 1)}
               >
-                Delete
+                ‹ Previous
+              </button>
+              <span className="muted small">
+                Page {page} of {totalPages}
+              </span>
+              <button
+                className="btn small"
+                disabled={page >= totalPages || isFetching}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next ›
               </button>
             </div>
-          </div>
-        ))}
-        {data && data.items.length === 0 && <p className="muted">No assets yet.</p>}
-      </div>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/src/pages/post-editor.tsx
+++ b/src/pages/post-editor.tsx
@@ -189,9 +189,9 @@ export function PostEditorPage() {
 
         <label className="stacked">
           <span>Excerpt</span>
-          <textarea
-            rows={3}
+          <input
             value={form.excerpt}
+            maxLength={500}
             onChange={(e) => set('excerpt', e.target.value)}
           />
         </label>
@@ -257,11 +257,12 @@ export function PostEditorPage() {
       <div className="editor-split">
         <div className="editor-pane">
           <span className="pane-label">Markdown</span>
+          {/* No height prop: .editor-split sizes both panes from one variable,
+              so the editor and the preview can never disagree. */}
           <CodeMirror
             value={form.contentMd}
             extensions={extensions}
             onChange={(value) => set('contentMd', value)}
-            height="520px"
             basicSetup={{ lineNumbers: true, foldGutter: false }}
           />
         </div>

--- a/src/pages/post-editor.tsx
+++ b/src/pages/post-editor.tsx
@@ -8,6 +8,7 @@ import { ApiError, errorMessage } from '@/api/client';
 import { createPost, deletePost, getPost, updatePost } from '@/api/posts';
 import type { PostInput, PostType } from '@/api/types';
 import { AssetPicker } from '@/components/asset-picker';
+import { LoadingBlock } from '@/components/loader';
 import { MarkdownPreview } from '@/components/markdown-preview';
 import { TagInput } from '@/components/tag-input';
 import { useToast } from '@/components/toast';
@@ -34,7 +35,7 @@ export function PostEditorPage() {
   const [form, setForm] = useState<PostInput>(EMPTY);
   const [slugTouched, setSlugTouched] = useState(false);
 
-  const { data: existing } = useQuery({
+  const { data: existing, isLoading } = useQuery({
     queryKey: ['post', id],
     queryFn: () => getPost(id as string),
     enabled: !isNew,
@@ -112,6 +113,15 @@ export function PostEditorPage() {
   const slugInvalid = form.slug.trim() !== '' && !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(form.slug);
   const canSave = form.title.trim() !== '' && form.slug.trim() !== '' && !slugInvalid;
 
+  if (isLoading) {
+    return (
+      <div className="page editor-page">
+        <h1 className="page-h1">Edit post</h1>
+        <LoadingBlock label="Loading post…" />
+      </div>
+    );
+  }
+
   return (
     <div className="page editor-page">
       <div className="page-head-row">
@@ -146,125 +156,121 @@ export function PostEditorPage() {
         </div>
       </div>
 
-      <div className="editor-layout">
-        <div className="editor-main">
-          <label className="stacked">
-            <span>Title</span>
-            <input value={form.title} onChange={(e) => onTitleChange(e.target.value)} />
-          </label>
+      <label className="stacked editor-title">
+        <span>Title</span>
+        <input value={form.title} onChange={(e) => onTitleChange(e.target.value)} />
+      </label>
 
-          <div className="editor-split">
-            <div className="editor-pane">
-              <span className="pane-label">Markdown</span>
-              <CodeMirror
-                value={form.contentMd}
-                extensions={extensions}
-                onChange={(value) => set('contentMd', value)}
-                height="520px"
-                basicSetup={{ lineNumbers: true, foldGutter: false }}
-              />
-            </div>
-            <div className="editor-pane">
-              <span className="pane-label">Preview</span>
-              <div className="preview-scroll">
-                <MarkdownPreview markdown={form.contentMd} />
-              </div>
-            </div>
+      {/* Post metadata sits above the panes so the editor and preview get the
+          full page width — this is where the time is actually spent. */}
+      <section className="editor-meta">
+        <label className="stacked">
+          <span>Type</span>
+          <select value={form.type} onChange={(e) => set('type', e.target.value as PostType)}>
+            <option value="article">Article</option>
+            <option value="project">Project</option>
+          </select>
+        </label>
+
+        <label className="stacked">
+          <span>Slug</span>
+          <input
+            value={form.slug}
+            aria-invalid={slugInvalid}
+            onChange={(e) => {
+              setSlugTouched(true);
+              set('slug', e.target.value);
+            }}
+          />
+          {slugInvalid && (
+            <span className="field-error">Lowercase letters, numbers and single hyphens only.</span>
+          )}
+        </label>
+
+        <label className="stacked">
+          <span>Excerpt</span>
+          <textarea
+            rows={3}
+            value={form.excerpt}
+            onChange={(e) => set('excerpt', e.target.value)}
+          />
+        </label>
+
+        <label className="stacked">
+          <span>Tags</span>
+          <TagInput value={form.tags} onChange={(tags) => set('tags', tags)} />
+        </label>
+
+        {form.type === 'project' && (
+          <label className="stacked">
+            <span>Repo URL</span>
+            <input
+              value={form.repoUrl ?? ''}
+              onChange={(e) => set('repoUrl', e.target.value || undefined)}
+            />
+          </label>
+        )}
+
+        <label className="stacked">
+          <span>Hero image</span>
+          <AssetPicker
+            value={form.heroAssetId ?? null}
+            onChange={(assetId) => set('heroAssetId', assetId ?? undefined)}
+          />
+        </label>
+
+        <label className="inline">
+          <input
+            type="checkbox"
+            checked={form.featured}
+            onChange={(e) => set('featured', e.target.checked)}
+          />
+          <span>Featured (shown on the home page)</span>
+        </label>
+
+        <details className="seo-block">
+          <summary>SEO overrides</summary>
+          <label className="stacked">
+            <span>SEO title</span>
+            <input
+              value={form.seoTitle ?? ''}
+              onChange={(e) => set('seoTitle', e.target.value || undefined)}
+            />
+          </label>
+          <label className="stacked">
+            <span>SEO description</span>
+            <textarea
+              rows={2}
+              value={form.seoDescription ?? ''}
+              onChange={(e) => set('seoDescription', e.target.value || undefined)}
+            />
+          </label>
+        </details>
+
+        {existing && (
+          <p className="muted small">
+            {existing.published ? 'Published' : 'Draft'} · ~{existing.readingTimeMin} min read
+          </p>
+        )}
+      </section>
+
+      <div className="editor-split">
+        <div className="editor-pane">
+          <span className="pane-label">Markdown</span>
+          <CodeMirror
+            value={form.contentMd}
+            extensions={extensions}
+            onChange={(value) => set('contentMd', value)}
+            height="520px"
+            basicSetup={{ lineNumbers: true, foldGutter: false }}
+          />
+        </div>
+        <div className="editor-pane">
+          <span className="pane-label">Preview</span>
+          <div className="preview-scroll">
+            <MarkdownPreview markdown={form.contentMd} />
           </div>
         </div>
-
-        <aside className="editor-sidebar">
-          <label className="stacked">
-            <span>Type</span>
-            <select value={form.type} onChange={(e) => set('type', e.target.value as PostType)}>
-              <option value="article">Article</option>
-              <option value="project">Project</option>
-            </select>
-          </label>
-
-          <label className="stacked">
-            <span>Slug</span>
-            <input
-              value={form.slug}
-              aria-invalid={slugInvalid}
-              onChange={(e) => {
-                setSlugTouched(true);
-                set('slug', e.target.value);
-              }}
-            />
-            {slugInvalid && (
-              <span className="field-error">
-                Lowercase letters, numbers and single hyphens only.
-              </span>
-            )}
-          </label>
-
-          <label className="stacked">
-            <span>Excerpt</span>
-            <textarea
-              rows={3}
-              value={form.excerpt}
-              onChange={(e) => set('excerpt', e.target.value)}
-            />
-          </label>
-
-          <label className="stacked">
-            <span>Tags</span>
-            <TagInput value={form.tags} onChange={(tags) => set('tags', tags)} />
-          </label>
-
-          {form.type === 'project' && (
-            <label className="stacked">
-              <span>Repo URL</span>
-              <input
-                value={form.repoUrl ?? ''}
-                onChange={(e) => set('repoUrl', e.target.value || undefined)}
-              />
-            </label>
-          )}
-
-          <label className="stacked">
-            <span>Hero image</span>
-            <AssetPicker
-              value={form.heroAssetId ?? null}
-              onChange={(assetId) => set('heroAssetId', assetId ?? undefined)}
-            />
-          </label>
-
-          <label className="inline">
-            <input
-              type="checkbox"
-              checked={form.featured}
-              onChange={(e) => set('featured', e.target.checked)}
-            />
-            <span>Featured (shown on the home page)</span>
-          </label>
-
-          <details className="seo-block">
-            <summary>SEO overrides</summary>
-            <label className="stacked">
-              <span>SEO title</span>
-              <input
-                value={form.seoTitle ?? ''}
-                onChange={(e) => set('seoTitle', e.target.value || undefined)}
-              />
-            </label>
-            <label className="stacked">
-              <span>SEO description</span>
-              <textarea
-                rows={2}
-                value={form.seoDescription ?? ''}
-                onChange={(e) => set('seoDescription', e.target.value || undefined)}
-              />
-            </label>
-          </details>
-
-          {existing && (
-            <p className="muted small">
-              {existing.published ? 'Published' : 'Draft'} · ~{existing.readingTimeMin} min read
-            </p>
-          )}
-        </aside>
       </div>
     </div>
   );

--- a/src/pages/post-editor.tsx
+++ b/src/pages/post-editor.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import CodeMirror from '@uiw/react-codemirror';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { ApiError } from '@/api/client';
+import { ApiError, errorMessage } from '@/api/client';
 import { createPost, deletePost, getPost, updatePost } from '@/api/posts';
 import type { PostInput, PostType } from '@/api/types';
 import { AssetPicker } from '@/components/asset-picker';
@@ -91,7 +91,7 @@ export function PostEditorPage() {
       if (err instanceof ApiError && err.status === 409) {
         toast('That slug is already in use.', 'error');
       } else {
-        toast('Save failed.', 'error');
+        toast(errorMessage(err, 'Save failed.'), 'error');
       }
     },
   });
@@ -106,7 +106,11 @@ export function PostEditorPage() {
     onError: () => toast('Delete failed.', 'error'),
   });
 
-  const canSave = form.title.trim() !== '' && form.slug.trim() !== '';
+  // Mirrors the API's @Matches on CreatePostDto.slug. Without this the button
+  // stays enabled for something like "My Post!", the request 400s, and the only
+  // signal is a toast after the round trip.
+  const slugInvalid = form.slug.trim() !== '' && !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(form.slug);
+  const canSave = form.title.trim() !== '' && form.slug.trim() !== '' && !slugInvalid;
 
   return (
     <div className="page editor-page">
@@ -182,11 +186,17 @@ export function PostEditorPage() {
             <span>Slug</span>
             <input
               value={form.slug}
+              aria-invalid={slugInvalid}
               onChange={(e) => {
                 setSlugTouched(true);
                 set('slug', e.target.value);
               }}
             />
+            {slugInvalid && (
+              <span className="field-error">
+                Lowercase letters, numbers and single hyphens only.
+              </span>
+            )}
           </label>
 
           <label className="stacked">

--- a/src/pages/posts-list.tsx
+++ b/src/pages/posts-list.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { listPosts } from '@/api/posts';
 import type { PostType } from '@/api/types';
+import { LoadingBlock } from '@/components/loader';
 
 export function PostsListPage() {
   const [type, setType] = useState<'' | PostType>('');
@@ -49,7 +50,7 @@ export function PostsListPage() {
       </div>
 
       {isLoading ? (
-        <p className="muted">Loading…</p>
+        <LoadingBlock label="Loading posts…" />
       ) : !data || data.items.length === 0 ? (
         <p className="muted">No posts yet.</p>
       ) : (

--- a/src/pages/site-settings.tsx
+++ b/src/pages/site-settings.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { errorMessage } from '@/api/client';
 import { getSiteConfig, updateSiteConfig, type SiteConfig } from '@/api/site';
+import { LoadingBlock } from '@/components/loader';
 import { useToast } from '@/components/toast';
 
 const EMPTY: SiteConfig = {
@@ -18,7 +19,7 @@ export function SiteSettingsPage() {
   const toast = useToast();
   const [form, setForm] = useState<SiteConfig>(EMPTY);
 
-  const { data } = useQuery({ queryKey: ['config'], queryFn: getSiteConfig });
+  const { data, isLoading } = useQuery({ queryKey: ['config'], queryFn: getSiteConfig });
 
   useEffect(() => {
     if (data) {
@@ -49,6 +50,15 @@ export function SiteSettingsPage() {
   const invalidLinks = form.socialLinks
     .map((link, index) => ({ link, index }))
     .filter(({ link }) => !/^https?:\/\/\S+\.\S+/.test(link.url.trim()));
+
+  if (isLoading) {
+    return (
+      <div className="page">
+        <h1 className="page-h1">Site settings</h1>
+        <LoadingBlock label="Loading settings…" />
+      </div>
+    );
+  }
 
   return (
     <div className="page">

--- a/src/pages/site-settings.tsx
+++ b/src/pages/site-settings.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
+import { errorMessage } from '@/api/client';
 import { getSiteConfig, updateSiteConfig, type SiteConfig } from '@/api/site';
 import { useToast } from '@/components/toast';
 
@@ -34,7 +35,7 @@ export function SiteSettingsPage() {
       queryClient.invalidateQueries({ queryKey: ['config'] });
       toast('Saved');
     },
-    onError: () => toast('Save failed.', 'error'),
+    onError: (err) => toast(errorMessage(err, 'Save failed.'), 'error'),
   });
 
   const setLink = (index: number, key: 'label' | 'url', value: string) =>
@@ -43,11 +44,21 @@ export function SiteSettingsPage() {
       form.socialLinks.map((link, i) => (i === index ? { ...link, [key]: value } : link)),
     );
 
+  // The API validates every social link with @IsUrl; catch it here so the
+  // button explains the problem instead of the request failing after the fact.
+  const invalidLinks = form.socialLinks
+    .map((link, index) => ({ link, index }))
+    .filter(({ link }) => !/^https?:\/\/\S+\.\S+/.test(link.url.trim()));
+
   return (
     <div className="page">
       <div className="page-head-row">
         <h1 className="page-h1">Site settings</h1>
-        <button className="btn primary" disabled={save.isPending} onClick={() => save.mutate()}>
+        <button
+          className="btn primary"
+          disabled={save.isPending || invalidLinks.length > 0}
+          onClick={() => save.mutate()}
+        >
           Save
         </button>
       </div>
@@ -83,6 +94,7 @@ export function SiteSettingsPage() {
               <input
                 placeholder="https://…"
                 value={link.url}
+                aria-invalid={invalidLinks.some((l) => l.index === index)}
                 onChange={(e) => setLink(index, 'url', e.target.value)}
               />
               <button

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -236,8 +236,16 @@ textarea[aria-invalid='true'] {
   margin-top: auto;
 }
 
+/*
+ * The width cap lives on the page, not the shell, so a page can opt out of it.
+ * Forms read better in a column; the post editor does not, and takes the whole
+ * viewport instead (.editor-page).
+ */
 .admin-main {
   padding: 32px 40px;
+}
+
+.page {
   max-width: 960px;
 }
 
@@ -399,11 +407,32 @@ textarea[aria-invalid='true'] {
   gap: 8px;
 }
 
-.editor-layout {
+/*
+ * Metadata as a horizontal band above the panes. auto-fill keeps it compact on
+ * a wide screen and collapses to a single column on a narrow one, so the
+ * editor and preview below always get the full width.
+ */
+.editor-meta {
   display: grid;
-  grid-template-columns: 1fr 300px;
-  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 0 20px;
   align-items: start;
+  margin: 4px 0 20px;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--wash);
+}
+
+/* Full-bleed rows inside the metadata band. */
+.editor-meta .inline,
+.editor-meta .seo-block,
+.editor-meta > .muted.small {
+  grid-column: 1 / -1;
+}
+
+.editor-title {
+  max-width: 720px;
 }
 
 .stacked {
@@ -425,6 +454,14 @@ textarea[aria-invalid='true'] {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
+  /* Panes track the viewport so a wide screen buys height as well as width. */
+  --editor-height: max(520px, calc(100vh - 380px));
+}
+
+@media (max-width: 1100px) {
+  .editor-split {
+    grid-template-columns: 1fr;
+  }
 }
 
 .editor-pane {
@@ -453,25 +490,12 @@ textarea[aria-invalid='true'] {
 }
 
 .preview-scroll {
-  height: 520px;
+  height: var(--editor-height);
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--surface);
   padding: 18px 20px;
-}
-
-.editor-sidebar {
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--wash);
-  padding: 18px;
-  position: sticky;
-  top: 24px;
-}
-
-.editor-sidebar .stacked:last-child {
-  margin-bottom: 0;
 }
 
 .inline {
@@ -631,14 +655,41 @@ textarea[aria-invalid='true'] {
   background: var(--chip);
 }
 
-.asset-search {
+.asset-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   margin-bottom: 20px;
 }
 
+.asset-search {
+  flex: 1;
+}
+
+.inline-select {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+
+.inline-select select {
+  width: auto;
+}
+
+.asset-count {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+/* Wider cards than before: they now carry a caption as well as the image. */
 .asset-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
   gap: 16px;
+  align-items: start;
 }
 
 .asset-card {
@@ -646,6 +697,39 @@ textarea[aria-invalid='true'] {
   border-radius: 8px;
   overflow: hidden;
   background: var(--surface);
+}
+
+.asset-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px 10px 2px;
+  min-width: 0;
+}
+
+/* Long names truncate rather than stretching the grid column. */
+.asset-meta > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-name {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.asset-facts {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.asset-alt {
+  font-size: 11.5px;
+  color: var(--secondary);
 }
 
 .asset-card img {
@@ -664,6 +748,40 @@ textarea[aria-invalid='true'] {
 .btn.small {
   padding: 5px 9px;
   font-size: 11px;
+}
+
+/* Loading */
+
+.spinner {
+  display: inline-flex;
+  color: var(--muted);
+}
+
+.spinner svg {
+  animation: spin 800ms linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loading-block {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 48px 0;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner svg {
+    animation-duration: 2400ms;
+  }
 }
 
 /* Toast */

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -167,6 +167,17 @@ select:focus {
   color: var(--danger);
 }
 
+/* Inline hint under a single invalid field, sized to sit inside .stacked. */
+.field-error {
+  font-size: 12px;
+  color: var(--danger);
+}
+
+input[aria-invalid='true'],
+textarea[aria-invalid='true'] {
+  border-color: var(--danger);
+}
+
 /* --- App shell --------------------------------------------------------------- */
 
 .admin-shell {

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -242,7 +242,9 @@ textarea[aria-invalid='true'] {
  * viewport instead (.editor-page).
  */
 .admin-main {
-  padding: 32px 40px;
+  /* Generous bottom padding: with only 32px the last row of a long page sat
+     hard against the viewport edge, which reads as unreachable. */
+  padding: 32px 40px 72px;
 }
 
 .page {
@@ -400,6 +402,10 @@ textarea[aria-invalid='true'] {
 
 .editor-page {
   max-width: none;
+  display: flex;
+  flex-direction: column;
+  /* Matches .admin-main's vertical padding, so the page ends at the fold. */
+  min-height: calc(100svh - 104px);
 }
 
 .editor-actions {
@@ -450,25 +456,44 @@ textarea[aria-invalid='true'] {
   color: var(--muted);
 }
 
+/*
+ * The panes fill whatever the page has left rather than being sized from a
+ * guessed offset: the editor page is a flex column, the split is the growing
+ * child, and each pane's body grows inside it. Both panes therefore always
+ * agree, and the page ends exactly at the fold whatever the metadata band
+ * happens to wrap to.
+ */
 .editor-split {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
-  /* Panes track the viewport so a wide screen buys height as well as width. */
-  --editor-height: max(520px, calc(100vh - 380px));
+  flex: 1 1 auto;
+  min-height: 420px;
+}
+
+/*
+ * auto row for the label, 1fr for the body. A definite row height is what lets
+ * CodeMirror fill its pane — with flex-grow alone it kept sizing to its content
+ * while the preview filled, which is exactly the mismatch this replaced.
+ */
+.editor-pane {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 8px;
+  min-width: 0;
+  height: 100%;
+}
+
+.editor-pane .cm-editor,
+.editor-pane .preview-scroll {
+  height: 100%;
+  min-height: 0;
 }
 
 @media (max-width: 1100px) {
   .editor-split {
     grid-template-columns: 1fr;
   }
-}
-
-.editor-pane {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 0;
 }
 
 .pane-label {
@@ -490,7 +515,6 @@ textarea[aria-invalid='true'] {
 }
 
 .preview-scroll {
-  height: var(--editor-height);
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: 8px;


### PR DESCRIPTION
Three rounds of work on the admin. **Depends on `personal-blog-api#50`** for the asset `filename` field — merge that first.

## Editor panes now match

The preview was sized from the viewport while CodeMirror carried a hardcoded `520px`, so the two disagreed by more the taller the screen (520 against 700 at 1080p) and the longer one ran past where the page ended.

Both panes now fill a row the page hands them: the editor page is a flex column, the split grows into what is left, and each pane is a grid whose second row is the body. That also removes the guessed viewport offset, so the page ends exactly at the fold rather than overshooting.

| Viewport | Editor | Preview | Page scroll |
| --- | --- | --- | --- |
| 1920×1080 | 569px | 569px | none |
| 2560×1440 | 929px | 929px | none |

## The editor gets the whole page

The width cap moved from the shell onto the page, so a page can opt out. Forms still read better in a column at 960px; the post editor does not. Its metadata — type, slug, excerpt, tags, hero, SEO — moved out of the right rail into a band **above** the panes. At 1920px each pane went from ~450px to 800px. Below 1100px the panes stack.

The excerpt is now a single-line input: it is one sentence that becomes the card blurb and the meta description, and a three-row textarea invited more than fits.

## Reachable page bottoms

Bottom padding goes from 32px to 72px. On a long assets page the last row of cards sat hard against the viewport edge with the pager right behind it, which reads as content you cannot reach. Now: 126px of clearance below the last card's buttons, 72px below the pager.

## Assets are identifiable

Previously a grid of thumbnails with no names, and search matched the content hash. Each card now shows upload name, type, size, date and alt text, with long names truncating rather than stretching the column. Search covers name and alt. Pages at 24/48/96. Verified with 37 assets: 24 + 13 across two pages, Next disabled on the last, search narrowing by either name or alt.

## Loading states

Every fetching page shows a labelled spinner instead of nothing or bare "Loading…" text; uploads show progress in the dropzone. Confirmed the loader actually renders during navigation.

## Form validation

Three forms let you submit payloads the API always rejects, reporting every rejection as a bare "Save failed."

| Form | Before |
| --- | --- |
| Post editor | `My Post!` kept both save buttons enabled, then 400'd |
| CV entries | **Save entry** enabled on a completely blank form |
| Site settings | A malformed social URL kept **Save** enabled |

All three now gate the button and name what is missing; `2025-02-30` is caught in the browser. Where the client cannot predict a rejection, `errorMessage()` surfaces the API's own text instead of discarding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)