### PR TITLE
Wrap long editor lines, show the TOTP key, stop tabs fighting over refresh

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -12,6 +12,8 @@ interface TokenResponse {
 }
 
 export interface MfaEnrollment {
+  /** Base32 TOTP key, for enrolling by paste instead of by camera. */
+  secret: string;
   otpauthUrl: string;
   qrDataUrl: string;
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -60,19 +60,36 @@ async function rawRequest(path: string, options: RequestOptions): Promise<Respon
   });
 }
 
+/**
+ * Callers that arrive while a refresh is already running wait for that one
+ * instead of starting another. Concurrent refreshes all present the same cookie
+ * and only the first can rotate it, so the rest would be spending requests to
+ * lean on the server's replay grace period. StrictMode alone fires the mount
+ * effect twice, which was enough to trigger it every single load.
+ */
+let inFlight: Promise<boolean> | null = null;
+
 /** Attempts a token refresh via the HttpOnly cookie. Returns true on success. */
 async function tryRefresh(): Promise<boolean> {
-  const res = await fetch(`${API_URL}/api/auth/refresh`, {
-    method: 'POST',
-    credentials: 'include',
-  });
-  if (!res.ok) {
-    setAccessToken(null);
-    return false;
+  if (inFlight) {
+    return inFlight;
   }
-  const data = (await res.json()) as { accessToken: string };
-  setAccessToken(data.accessToken);
-  return true;
+  inFlight = (async () => {
+    const res = await fetch(`${API_URL}/api/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      setAccessToken(null);
+      return false;
+    }
+    const data = (await res.json()) as { accessToken: string };
+    setAccessToken(data.accessToken);
+    return true;
+  })().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
 }
 
 /**

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -8,6 +8,39 @@ type Step =
   | { kind: 'mfa-verify'; tempToken: string }
   | { kind: 'mfa-setup'; tempToken: string; enrollment: MfaEnrollment };
 
+type CopyState = 'idle' | 'copied' | 'failed';
+
+/**
+ * The QR only helps if you are enrolling with a phone camera. A password manager
+ * wants the key as text, so show it too — and make it a one-click copy, because
+ * a mistyped base32 character fails at verification with no clue why.
+ */
+function SetupKey({ secret }: { secret: string }) {
+  const [copy, setCopy] = useState<CopyState>('idle');
+
+  // Absent in insecure contexts, where the property access itself throws.
+  const copySecret = async () => {
+    try {
+      await navigator.clipboard.writeText(secret);
+      setCopy('copied');
+    } catch {
+      setCopy('failed');
+    }
+    window.setTimeout(() => setCopy('idle'), 2000);
+  };
+
+  return (
+    <div className="setup-key">
+      <span className="setup-key-label">Setup key</span>
+      {/* user-select: all — a single click grabs the whole key if copying fails. */}
+      <code>{secret}</code>
+      <button type="button" className="btn ghost small" onClick={copySecret}>
+        {copy === 'copied' ? 'Copied' : copy === 'failed' ? 'Copy failed' : 'Copy'}
+      </button>
+    </div>
+  );
+}
+
 function errorMessage(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.status === 401) {
@@ -107,9 +140,11 @@ export function LoginPage() {
         {step.kind === 'mfa-setup' && (
           <form onSubmit={submitCode} className="login-form">
             <p className="login-hint">
-              Scan this with your authenticator app, then enter the 6-digit code to finish setup.
+              Scan the QR with an authenticator app, or add the setup key to a password manager.
+              Then enter the 6-digit code to finish setup.
             </p>
             <img className="qr" src={step.enrollment.qrDataUrl} alt="MFA QR code" />
+            <SetupKey secret={step.enrollment.secret} />
             <label>
               <span>Authentication code</span>
               <input

--- a/src/pages/post-editor.tsx
+++ b/src/pages/post-editor.tsx
@@ -1,7 +1,7 @@
 import { markdown as cmMarkdown } from '@codemirror/lang-markdown';
 import { languages } from '@codemirror/language-data';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import CodeMirror from '@uiw/react-codemirror';
+import CodeMirror, { EditorView } from '@uiw/react-codemirror';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { ApiError, errorMessage } from '@/api/client';
@@ -72,7 +72,12 @@ export function PostEditorPage() {
     }));
   };
 
-  const extensions = useMemo(() => [cmMarkdown({ codeLanguages: languages })], []);
+  // Soft wrap: prose paragraphs are written as one long line, and without this
+  // the editor sizes itself to the longest one instead of to its pane.
+  const extensions = useMemo(
+    () => [cmMarkdown({ codeLanguages: languages }), EditorView.lineWrapping],
+    [],
+  );
 
   const save = useMutation({
     mutationFn: (publish: boolean) => {

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -124,6 +124,38 @@ a {
   border-radius: 8px;
 }
 
+.setup-key {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--wash);
+}
+
+.setup-key-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.setup-key code {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text);
+  /* The key is one token: never hyphenate it, and select all of it at once. */
+  word-break: break-all;
+  user-select: all;
+}
+
+.setup-key .btn {
+  align-self: flex-start;
+}
+
 /* --- Forms ------------------------------------------------------------------- */
 
 label {
@@ -476,9 +508,16 @@ textarea[aria-invalid='true'] {
  * CodeMirror fill its pane — with flex-grow alone it kept sizing to its content
  * while the preview filled, which is exactly the mismatch this replaced.
  */
+/*
+ * minmax(0, 1fr) on the column, not just min-width: 0 on the pane. The pane can
+ * shrink either way, but its implicit column would still be max-content, so a
+ * long line sized CodeMirror past the pane and painted it over the preview
+ * instead of scrolling inside it.
+ */
 .editor-pane {
   display: grid;
   grid-template-rows: auto 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: 8px;
   min-width: 0;
   height: 100%;

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -6,6 +6,10 @@
   font-size: 15px;
   line-height: 1.7;
   color: var(--body);
+  /* A bare URL offers no break opportunity, and one of them was enough to make
+     the preview three times its pane. `pre` is unaffected — it does not wrap, so
+     code keeps the horizontal scroll it needs to stay readable as written. */
+  overflow-wrap: break-word;
 }
 
 .prose > * + * {


### PR DESCRIPTION
## Editor overflow

A paragraph written as one long line sized CodeMirror to its own content and painted it across the preview pane, hiding the first few hundred pixels of the rendered text.

Measured at 1920px on a post whose first line is long:

| | before | after |
|---|---|---|
| pane (grid column) | 802px | 802px |
| `.cm-editor` | **1111px** | 802px |
| preview left edge | 1078px, painted over | 1078px, clear |

The grid columns were always correct. `.editor-pane` is itself a grid, and its *implicit* column is `auto` — which sizes to max-content. `min-width: 0` let the pane shrink, but the track inside it still expanded, so the editor overflowed. The column is now `minmax(0, 1fr)`, and the editor soft-wraps via `EditorView.lineWrapping`.

The preview had the same defect from a different direction: one bare URL made its `<p>` 2564px inside an 800px box. `.prose` now breaks long words; `pre` is unaffected because it does not wrap, so code keeps the horizontal scroll it needs to stay readable as written.

Verified with a 523-character unbreakable token: editor stays at 802/802, preview stops overflowing, page has zero horizontal overflow.

## MFA enrolment shows the setup key

The QR only helps when enrolling with a phone camera. The base32 key is now shown beneath it with a copy button, for password managers.

Copy writes the key with no spaces or grouping so it pastes cleanly into a manager that is strict about base32. If the clipboard API is unavailable the button says so rather than doing nothing, and the key is `user-select: all` as a fallback. Verified end to end: a TOTP generated from the displayed key completes enrolment.

## Refresh single-flight

Callers arriving while a refresh is in flight now wait for it instead of starting another.

They all present the same cookie and only the first can rotate it, so the rest were spending requests to lean on the server's replay grace. `StrictMode` fires the mount effect twice, which triggered this on **every single load** — and paired with the server's old replay handling, that is what logged every tab out when a new one opened.

Pairs with personal-blog-api#51, which fixes the server half.

## Testing

`typecheck` and `lint` clean. Three live tabs stay authenticated across reloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)