### PR TITLE
Add the maintenance-mode switch to site settings

### DIFF
--- a/src/api/site.ts
+++ b/src/api/site.ts
@@ -85,6 +85,15 @@ export const getSiteConfig = () => apiRequest<SiteConfig>('/config');
 export const updateSiteConfig = (input: SiteConfig) =>
   apiRequest<SiteConfig>('/admin/config', { method: 'PUT', body: input });
 
+// --- maintenance mode (deploy switch, separate from the config form) ---
+export interface MaintenanceState {
+  enabled: boolean;
+}
+
+export const getMaintenance = () => apiRequest<MaintenanceState>('/maintenance');
+export const updateMaintenance = (enabled: boolean) =>
+  apiRequest<MaintenanceState>('/admin/maintenance', { method: 'PUT', body: { enabled } });
+
 // --- about ---
 export const getAbout = () => apiRequest<AboutData>('/admin/about');
 export const updateAbout = (input: AboutInput) =>

--- a/src/pages/site-settings.tsx
+++ b/src/pages/site-settings.tsx
@@ -1,9 +1,65 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { errorMessage } from '@/api/client';
-import { getSiteConfig, updateSiteConfig, type SiteConfig } from '@/api/site';
+import {
+  getMaintenance,
+  getSiteConfig,
+  updateMaintenance,
+  updateSiteConfig,
+  type SiteConfig,
+} from '@/api/site';
 import { LoadingBlock } from '@/components/loader';
 import { useToast } from '@/components/toast';
+
+/** The deploy switch: instant, separate from the Save button below it. */
+function MaintenanceCard() {
+  const queryClient = useQueryClient();
+  const toast = useToast();
+
+  const { data } = useQuery({ queryKey: ['maintenance'], queryFn: getMaintenance });
+
+  const toggle = useMutation({
+    mutationFn: (enabled: boolean) => updateMaintenance(enabled),
+    onSuccess: (state) => {
+      queryClient.setQueryData(['maintenance'], state);
+      toast(state.enabled ? 'Maintenance mode is on' : 'The site is live again');
+    },
+    onError: (err) => toast(errorMessage(err, 'Toggling maintenance failed.'), 'error'),
+  });
+
+  if (!data) {
+    return null;
+  }
+
+  const flip = () => {
+    if (
+      data.enabled ||
+      confirm('Take the public site down? Every visitor will be redirected to /maintenance.')
+    ) {
+      toggle.mutate(!data.enabled);
+    }
+  };
+
+  return (
+    <div className={`maintenance-card${data.enabled ? ' on' : ''}`}>
+      <div>
+        <span className="field-label">Maintenance mode</span>
+        <p className="maintenance-status">
+          {data.enabled
+            ? 'The public site is down — every page redirects to /maintenance.'
+            : 'The public site is live.'}
+        </p>
+      </div>
+      <button
+        className={`btn${data.enabled ? ' primary' : ' danger'}`}
+        disabled={toggle.isPending}
+        onClick={flip}
+      >
+        {data.enabled ? 'Bring the site back' : 'Enable maintenance'}
+      </button>
+    </div>
+  );
+}
 
 const EMPTY: SiteConfig = {
   heroTitle: '',
@@ -72,6 +128,8 @@ export function SiteSettingsPage() {
           Save
         </button>
       </div>
+
+      <MaintenanceCard />
 
       <label className="stacked">
         <span>Hero title</span>

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -899,6 +899,34 @@ textarea[aria-invalid='true'] {
   gap: 16px;
 }
 
+/* The deploy switch on the settings page; unmissable when the site is down. */
+.maintenance-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 16px 20px;
+  margin-bottom: 24px;
+}
+
+.maintenance-card.on {
+  border-color: var(--danger);
+}
+
+.maintenance-status {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.maintenance-card.on .maintenance-status {
+  color: var(--danger);
+}
+
 .social-links {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What

A card above the site-settings form with an instant toggle for the new maintenance endpoints:

- Enabling asks for confirmation ("Take the public site down?") and paints the card red with a "the public site is down" status line.
- Disabling is a single click — no confirm on the way back up.
- It has its own query + mutation (`GET /maintenance`, `PUT /admin/maintenance`), fully independent of the form's Save button.

## Testing

tsc + eslint clean; Playwright-verified against the running stack: confirm dialog, state flip, and the public site actually redirecting/restoring.

Pairs with personal-blog-api's maintenance PR (endpoints) and personal-blog-front's (middleware + pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)