### PR TITLE
Docs: maintenance switch, infrastructure-repo pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Part of a three-repo system: `personal-blog-api` (content API), `personal-blog-f
 
 ## Screens
 
-Login (credentials → TOTP setup/challenge) · Dashboard · Posts (list + editor) · Assets (upload/manage) · About / CV (profile + work/education/certifications CRUD) · Site settings (hero, intro, social links, SEO, footer) · Security (change password).
+Login (credentials → TOTP setup/challenge) · Dashboard · Posts (list + editor) · Assets (upload/manage) · About / CV (profile + work/education/certifications CRUD) · Site settings (hero, intro, social links, SEO, footer, maintenance-mode switch) · Security (change password).
 
 ## Development
 
@@ -37,4 +37,4 @@ npm run dev            # http://localhost:4200
 
 ## Deployment
 
-Static build served by nginx (SPA fallback). Docker image built by `.github/workflows/deploy.yml` → GHCR → SSH deploy into the EC2 compose stack. Infra lives in the API repo's [`deploy/`](https://github.com/mikhailbahdashych/personal-blog-api/tree/master/deploy).
+Static build served by nginx (SPA fallback). Docker image built by `.github/workflows/deploy.yml` → GHCR → SSH deploy into the EC2 compose stack. All infrastructure (Terraform, compose stack, nginx) lives in [personal-blog-infrastructure](https://github.com/mikhailbahdashych/personal-blog-infrastructure) — including the nginx IP allowlist that restricts this panel's vhost to known addresses before auth is even attempted.


### PR DESCRIPTION
- Site settings screen list now includes the maintenance-mode switch
- Deployment section points at [personal-blog-infrastructure](https://github.com/mikhailbahdashych/personal-blog-infrastructure) instead of the API repo's deleted `deploy/`, and mentions the nginx IP allowlist guarding this panel's vhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)