### PR TITLE
Admin favicon and tab title

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex, nofollow" />
-    <title>Blog Admin</title>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <title>Blog Admin - Mikhail Bahdashych</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Same mark as the blog (src/app/icon.svg there), inverted: the admin tab
+       sits next to the public site all day, so it reads as the same brand at a
+       glance while staying distinguishable. -->
+  <rect width="32" height="32" rx="6" fill="#fbfaf7" stroke="#1c1c1a" stroke-width="2" />
+  <text x="16" y="22" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="16" font-weight="700" fill="#1c1c1a" text-anchor="middle">mb</text>
+</svg>


### PR DESCRIPTION
- Adds `public/favicon.svg` — the same `mb` mark the blog uses (`src/app/icon.svg` there), inverted so the admin tab is distinguishable from the public site sitting next to it
- Tab title is now **Blog Admin - Mikhail Bahdashych**

Verified with `npm run build`: `favicon.svg` lands in `dist/` and nginx's `try_files $uri` serves it ahead of the SPA fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)